### PR TITLE
Add VectorUtils to cabal other-modules field

### DIFF
--- a/Ninjas.cabal
+++ b/Ninjas.cabal
@@ -24,7 +24,8 @@ executable Ninjas
                        NetworkMessages,
                        Parameters,
                        Server,
-                       Simulation
+                       Simulation,
+                       VectorUtils
   hs-source-dirs:      src
   build-depends:
                        base,


### PR DESCRIPTION
This small change is necessary to build the executable.
