### PR TITLE
Add bots to Ninjas

### DIFF
--- a/Ninjas.cabal
+++ b/Ninjas.cabal
@@ -25,7 +25,8 @@ executable Ninjas
                        Parameters,
                        Server,
                        Simulation,
-                       VectorUtils
+                       VectorUtils,
+                       Bot
   hs-source-dirs:      src
   build-depends:
                        base,
@@ -36,5 +37,37 @@ executable Ninjas
                        gloss,
                        network,
                        networked-game,
-                       random
+                       random,
+                       hint,
+                       stm-chans, stm,
+                       time
   ghc-options:         -Wall
+
+Library
+  other-modules:
+                       Anim,
+                       Client,
+                       Character,
+                       NetworkMessages,
+                       Parameters,
+                       Server,
+                       Simulation,
+                       Paths_Ninjas
+  hs-source-dirs:      src
+  build-depends:
+                       base,
+                       binary,
+                       bytestring,
+                       containers,
+                       filepath,
+                       gloss,
+                       network,
+                       networked-game,
+                       random,
+                       hint,
+                       stm-chans, stm,
+                       time
+  ghc-options:         -Wall
+  exposed-modules:     Ninja,
+                       Ninja.WhiteBelt,
+                       Bot

--- a/src/Anim.hs
+++ b/src/Anim.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 module Anim where
 
 import Graphics.Gloss.Data.Picture
 import Graphics.Gloss.Data.Bitmap (loadBMP)
 import System.FilePath
+import Data.Data
 import Control.Exception
 import Prelude
 
@@ -17,7 +19,7 @@ data Animation = Animation
   , moreFrames  :: [Picture]  -- ^ Total number of frames
   , waitFor     :: Float      -- ^ Time until next frame
   , curFrame    :: Picture    -- ^ Current frame
-  }
+  } deriving (Data, Typeable)
 
 loop :: Animation -> Animation
 loop a = a { moreFrames = cycle' (moreFrames a) }
@@ -69,6 +71,7 @@ loadAnim path = once defaultFrameDelay `fmap` loadFrames path
 
 
 data NPC = NPC { walk, stay, stun, attack, die :: Animation }
+        deriving (Data, Typeable)
 
 loadNPC :: IO NPC
 loadNPC =
@@ -82,6 +85,7 @@ loadNPC =
 
 data World = World { background, tower, smoke :: Animation
                    , npc :: NPC }
+        deriving (Data, Typeable)
 
 loadWorld :: IO World
 loadWorld =

--- a/src/Bot.hs
+++ b/src/Bot.hs
@@ -1,0 +1,394 @@
+{-# LANGUAGE StandaloneDeriving, RecordWildCards, DeriveDataTypeable #-}
+module Bot
+    ( -- * For internal use by Ninjas
+      BotEnv(..)
+    , Bot(..)
+    , defaultBotEnv
+    , botMain
+    -- * Helper functionallity for custom bots
+    , worldOf
+    -- ** Types
+    , BotHandle, BotEvent(..), InfoWorld(..)
+    , ClientCharacter(..), Character(..)
+    , State(..), WalkInfo(..), WaitInfo(..)
+    -- ** Bot commands
+    , move, stop, attack, start, smoke
+    ) where
+
+import Control.Concurrent
+import Control.Concurrent.STM.TBChan as C
+import Control.Concurrent.STM (atomically)
+import Control.Monad
+import qualified Control.Exception as X
+import Graphics.Gloss.Interface.IO.Game
+import Graphics.Gloss.Data.Vector
+import Graphics.Gloss.Geometry.Angle
+import System.IO
+import Network
+import Server (ServerEnv(..), defaultServerEnv)
+import NetworkMessages
+import qualified Data.IntMap as IntMap
+import Data.IntMap (IntMap)
+import Data.Time
+import System.Exit (exitSuccess)
+import Data.Data
+import Data.Dynamic
+
+import Character
+import Parameters
+import VectorUtils
+import qualified Anim
+
+import Language.Haskell.Interpreter
+
+windowPadding :: Int
+windowPadding = 60
+
+dingPeriod :: Float
+dingPeriod = 1
+
+textScale :: Float
+textScale = 0.25
+
+dingPosition :: Point
+dingPosition = (fst boardMin + 5, snd boardMax - 20)
+
+data BotHandle = BotHandle Handle
+        deriving (Typeable)
+
+data BotEnv = BotEnv
+  { hostname   :: HostName
+  , clientPort :: Int
+  , botname    :: String
+  , bot        :: Bot
+  , runDisplay :: Bool
+  }
+
+defaultBotEnv :: BotEnv
+defaultBotEnv = BotEnv
+  { hostname   = "localhost"
+  , clientPort = serverPort defaultServerEnv
+  , botname    = "[Bot]Anon"
+  , bot        = defaultBot
+  , runDisplay = False
+  }
+
+data Bot = BotFile FilePath
+         | BotNoop
+
+defaultBot :: Bot
+defaultBot = BotNoop
+
+botMain :: BotEnv -> IO ()
+botMain (BotEnv host port botname bot runDisplay) =
+  do anim <- Anim.loadWorld
+     h <- connectTo host (PortNumber (fromIntegral port))
+     hSetBuffering h NoBuffering
+
+     cmdChan <- C.newTBChanIO 100
+     let bh = BotHandle h
+
+     hPutClientCommand h (ClientJoin botname)
+
+     poss <- getInitialWorld h
+     r <- newMVar (initBotWorld anim poss)
+     _ <- forkIO  $ botUpdates h cmdChan  r
+     _ <- forkIO' $ runBot bot bh cmdChan r
+     if runDisplay
+         then showGame h r
+         else don'tShowGame h r
+
+serverWaitingMessage :: Int -> String
+serverWaitingMessage n
+  = "Server waiting for "
+ ++ show n ++ " more ninja"
+ ++ if n > 1 then "s." else "."
+
+getInitialWorld :: Handle -> IO [(Int,Point,Vector)]
+getInitialWorld h =
+  do msg <- hGetServerCommand h
+     case msg of
+       SetWorld poss -> return poss
+       ServerWaiting n ->
+         do putStrLn $ serverWaitingMessage n
+            getInitialWorld h
+       _ -> fail "Unexpected initial message"
+
+initBotWorld :: Anim.World -> [(Int, Point, Vector)] -> World
+initBotWorld anim poss = World vw iw
+  where
+
+  iw :: InfoWorld
+  iw = InfoWorld (IntMap.map clientCharacter (worldCharacters vw)) []
+
+  vw :: VisibleWorld
+  vw = VisibleWorld
+        { worldCharacters = IntMap.fromList
+                            [(i,initClientCharacter (Anim.npc anim) p v)
+                                | (i,p,v) <- poss ]
+        , dingTimers    = []
+        , worldMessages = []
+        , smokeTimers   = []
+        , appearance    = anim
+        }
+
+forkIO' :: IO () -> IO ThreadId
+forkIO' f = do
+    me <- myThreadId
+    forkFinally f (\e -> print e >> X.throwTo me X.ThreadKilled)
+
+don'tShowGame :: Handle -> MVar World -> IO ()
+don'tShowGame _h var = do
+    let quitter = do
+            c <- getChar
+            when (c == 'q' || c == 'Q') exitSuccess
+            quitter
+    _ <- forkIO' quitter
+    t <- getCurrentTime
+    go t
+  where
+  go old = do
+    threadDelay (1000000 `div` eventsPerSecond)
+    now <- getCurrentTime
+    let diff = realToFrac (diffUTCTime now old)
+    modifyMVar_ var (return . updateBotWorld diff)
+    go now
+
+showGame :: Handle -> MVar World -> IO ()
+showGame _h var =
+     playIO
+       (InWindow "Ninjas"
+         (round width + windowPadding, round height + windowPadding)
+         (10,10))
+       black
+       eventsPerSecond
+       () -- "state"
+       (\() -> fmap (drawWorld . visibleWorld) (readMVar var))
+       inputEvent
+       (\t () -> modifyMVar_ var $ \w -> return $ updateBotWorld t w)
+  where (width,height) = subPt boardMax boardMin
+
+drawWorld      :: VisibleWorld -> Picture
+drawWorld w     = pictures
+                $ borderPicture
+                : dingPicture (length (dingTimers w))
+                : map (drawPillar w) pillars
+               ++ map drawCharacter (IntMap.elems $ worldCharacters w)
+               ++ map drawSmoke (smokeTimers w)
+               ++ messagePictures (worldMessages w)
+
+inputEvent :: Event -> () -> IO ()
+inputEvent (EventKey (Char 'Q') Down _ _) _ = exitSuccess
+inputEvent _ _ = return ()
+
+drawSmoke :: (Point, Anim.Animation) -> Picture
+drawSmoke (pt,a) = translateV pt (Anim.curFrame a)
+
+messagePictures :: [String] -> [Picture]
+messagePictures msgs = zipWith messagePicture [0..] msgs
+
+messagePicture :: Int -> String -> Picture
+messagePicture i msg
+  = translate (fst boardMin + 5)
+              (snd boardMin + 5 + textHeight * fromIntegral i)
+  $ scale textScale textScale
+  $ color (greyN gray)
+  $ text msg
+  where
+  textHeight = 40
+  gray = (4 - fromIntegral (min 3 i)) / 4
+
+dingPicture :: Int -> Picture
+dingPicture n =
+  pictures [ translateV dingPosition
+           $ translate (5 * fromIntegral i) (- 5 * fromIntegral i)
+           $ scale textScale textScale
+           $ color white
+           $ text "DING"
+           | i <- [0..n-1]]
+
+drawPillar :: VisibleWorld -> Point -> Picture
+drawPillar w pt
+  = translateV pt
+  $ Anim.curFrame $ Anim.tower $ appearance w
+
+borderPicture  :: Picture
+borderPicture   = color red $ rectangleWire (2 * ninjaRadius + width)
+                                            (2 * ninjaRadius + height)
+  where (width,height) = subPt boardMax boardMin
+
+drawCharacter :: ClientCharacter -> Picture
+drawCharacter c
+    = translateV (charPos char)
+    $ rotate (negate $ radToDeg rads)
+    $ Anim.curFrame (clientAnim c)
+  where char  = clientCharacter c
+        rads  = argV (charFacing char)
+
+-- | Translate a picture using a 'Vector'
+translateV :: Vector -> Picture -> Picture
+translateV (x,y) = translate x y
+
+data BotEvent = Cmd (ServerCommand,InfoWorld) | Tick InfoWorld
+        deriving (Data,Typeable)
+
+worldOf :: BotEvent -> InfoWorld
+worldOf (Cmd (_,x)) = x
+worldOf (Tick x)    = x
+
+runBot :: Bot -> BotHandle -> TBChan ServerCommand -> MVar World -> IO ()
+runBot BotNoop     _ _  _   = return ()
+runBot (BotFile f) h cc var = do
+  union <- newTBChanIO 100
+  let timer = do
+        threadDelay 50000
+        w <- readMVar var
+        atomically (writeTBChan union (Tick (infoWorld w)))
+      cmd = do
+          c <- atomically (readTBChan cc)
+          w <- readMVar var
+          atomically (writeTBChan union (Cmd (c,infoWorld w)))
+  _ <- forkIO (forever cmd)
+  _ <- forkIO (forever timer)
+  e <- runInterpreter $
+         do loadModules [f]
+            setImports ["Prelude","Ninja","Bot","Data.Dynamic"]
+            let ty :: BotHandle -> BotEvent -> Dynamic -> IO Dynamic
+                ty = undefined
+                tyBotWorld :: Dynamic
+                tyBotWorld = undefined
+            func <- interpret "ninja" ty
+            botW <- interpret "ninjaStance" tyBotWorld
+            let botLoop botWorld = do
+                 tick  <- atomically (readTBChan union)
+                 botW' <- func h tick botWorld
+                 botLoop botW'
+            liftIO $ botLoop botW
+  putStrLn "Bot interpreter exited"
+  case e of
+    Left err -> error (show err)
+    Right _  -> putStrLn "Bot exited normally"
+
+updateBotWorld :: Float -> World -> World
+updateBotWorld d (World w inf) = World vw iw
+  where
+  iw = InfoWorld (IntMap.map clientCharacter (worldCharacters vw))
+                 [(p, t - d) | (p,t) <- smokeLocations inf, t > d]
+  vw = w
+    { worldCharacters = fmap (stepClientCharacter npcLooks d) (worldCharacters w)
+    , dingTimers  = [ t - d      |  t     <- dingTimers  w, t > d]
+    , smokeTimers = [(pt, Anim.update d a) |
+                            (pt,a) <- smokeTimers w, not (Anim.finished d a) ]
+    , appearance  = Anim.updateWorld d (appearance w)
+    }
+  npcLooks = Anim.npc (appearance w)
+
+stepClientCharacter :: Anim.NPC -> Float -> ClientCharacter -> ClientCharacter
+stepClientCharacter looks elapsed clientChar =
+  case stepCharacter elapsed (clientCharacter clientChar) of
+    (char,changed,_)
+      | changed   -> newClientCharacter looks char
+      | otherwise -> clientChar { clientCharacter = char
+                                , clientAnim = Anim.update elapsed (clientAnim clientChar) }
+
+newClientCharacter :: Anim.NPC -> Character -> ClientCharacter
+newClientCharacter looks clientCharacter = ClientCharacter { .. }
+  where
+  clientAnim = case charState clientCharacter of
+                 Walking {}               -> Anim.walk looks
+                 Waiting w | waitStunned w -> Anim.stun   looks
+                           | otherwise    -> Anim.stay   looks
+                 Attacking {}             -> Anim.attack looks
+                 Dead                     -> Anim.die    looks
+
+botUpdates :: Handle -> TBChan ServerCommand -> MVar World -> IO ()
+botUpdates h cc var = forever $
+  do c <- hGetServerCommand h
+     modifyMVar_ var $ \w -> return $! processCmd w c
+     atomically $ writeTBChan cc c
+
+  where
+
+  processCmd wld@(World w inf) c =
+    let g x = World x inf in
+    case c of
+      ServerReady       -> g w { worldMessages = [] }
+      ServerMessage txt -> g w { worldMessages = txt : worldMessages w }
+      ServerDing        -> g w { dingTimers = dingPeriod : dingTimers w }
+      ServerSmoke pt    -> let smokeA = Anim.smoke (appearance w)
+                           in g w { smokeTimers = (pt,smokeA) : smokeTimers w }
+      SetWorld poss     -> initBotWorld (appearance $ visibleWorld wld) poss
+      ServerCommand i m -> let f = npcCommand w m
+                           in g w { worldCharacters = updateNpcList i f $ worldCharacters w }
+      _                 -> wld
+
+  npcCommand w cmd cnpc =
+    let npc = clientCharacter cnpc
+    in newClientCharacter (Anim.npc $ appearance w) $
+       case cmd of
+         Move from to   -> walkingCharacter to npc { charPos = from }
+         Stop           -> waitingCharacter Nothing False npc
+         Stun           -> stunnedCharacter npc
+         Die            -> deadCharacter npc
+         Attack         -> attackingCharacter npc
+
+updateNpcList ::
+  Int ->
+  (ClientCharacter -> ClientCharacter) ->
+  IntMap ClientCharacter -> IntMap ClientCharacter
+updateNpcList i f = IntMap.update (Just . f) i
+
+data VisibleWorld = VisibleWorld
+  { worldCharacters  :: IntMap ClientCharacter
+  , dingTimers       :: [Float]
+  , smokeTimers      :: [(Point, Anim.Animation)]
+  , worldMessages    :: [String]
+  , appearance       :: Anim.World
+  } deriving (Data,Typeable)
+
+data InfoWorld = InfoWorld
+  { infoCharacters    :: IntMap Character
+  , smokeLocations    :: [(Point,Float)]
+  } deriving (Data,Typeable)
+
+data World = World
+  { visibleWorld     :: VisibleWorld
+  , infoWorld        :: InfoWorld
+  } deriving (Data, Typeable)
+
+-- | Construct a new character given a name, a position,
+-- and a facing unit vector. This function is used
+-- by clients who are told the parameters by the
+-- server.
+initClientCharacter :: Anim.NPC -> Point -> Vector -> ClientCharacter
+initClientCharacter anim charPos charFacing =
+  let charState = Waiting Wait { waitWaiting = Nothing, waitStunned = False }
+      clientAnim = Anim.stay anim
+      clientCharacter = Character { .. }
+  in  ClientCharacter { .. }
+
+data ClientCharacter = ClientCharacter
+  { clientCharacter  :: Character
+  , clientAnim       :: Anim.Animation
+  } deriving (Data, Typeable)
+
+-- Helper Functionallity for Bots
+
+-- Bot Commands
+bSendCommand :: BotHandle -> ClientCommand -> IO ()
+bSendCommand (BotHandle h) = hPutClientCommand h
+
+move     :: BotHandle -> Point -> IO ()
+move h   = bSendCommand h . ClientCommand . Move (0,0)
+
+stop     :: BotHandle -> IO ()
+stop h   = bSendCommand h (ClientCommand Stop)
+
+attack   :: BotHandle -> IO ()
+attack h = bSendCommand h (ClientCommand Attack)
+
+smoke    :: BotHandle -> IO ()
+smoke h  = bSendCommand h ClientSmoke
+
+start    :: BotHandle -> IO ()
+start h  = bSendCommand h NewGame

--- a/src/Character.hs
+++ b/src/Character.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 module Character where
 
+import Data.Data
 import Graphics.Gloss.Data.Point
 import Graphics.Gloss.Data.Vector
 
@@ -12,7 +14,7 @@ data Character = Character
   , charFacing :: Vector -- Unit vector
   , charState  :: State
   }
-  deriving (Read, Show, Eq)
+  deriving (Read, Show, Eq, Data, Typeable)
 
 data WalkInfo = Walk
   { walkTarget    :: Point
@@ -20,20 +22,20 @@ data WalkInfo = Walk
   , walkDist      :: Float
   , walkVelocity  :: Vector
   }
-  deriving (Show, Read, Eq)
+  deriving (Show, Read, Eq, Data, Typeable)
 
 data WaitInfo = Wait
   { waitWaiting :: Maybe Float
   , waitStunned :: Bool
   }
-  deriving (Show, Read, Eq)
+  deriving (Show, Read, Eq, Data, Typeable)
 
 data State
   = Walking WalkInfo
   | Waiting WaitInfo
   | Dead
   | Attacking Float
-  deriving (Show, Read, Eq)
+  deriving (Show, Read, Eq, Data, Typeable)
 
 data ThinkTask = ChooseWait | ChooseDestination
 

--- a/src/NetworkMessages.hs
+++ b/src/NetworkMessages.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 module NetworkMessages where
 
 import Control.Monad
 import Data.Binary (Binary(get,put),getWord8,putWord8, Get,Put)
+import Data.Data
 import Graphics.Gloss.Data.Picture
 import Network (PortID(PortNumber))
 import System.IO (Handle)
@@ -17,14 +19,14 @@ data Command
   | Attack
   | Stun
   | Die
-  deriving (Show, Read, Eq)
+  deriving (Show, Read, Eq, Data, Typeable)
 
 data ClientCommand
   = ClientCommand Command
   | ClientSmoke
   | ClientJoin String
   | NewGame
-  deriving (Show, Read, Eq)
+  deriving (Show, Read, Eq, Data, Typeable)
 
 data ServerCommand
   = ServerCommand Int Command
@@ -34,7 +36,7 @@ data ServerCommand
   | ServerSmoke Point
   | ServerDing
   | ServerReady
-  deriving (Show, Read)
+  deriving (Show, Read, Data, Typeable)
 
 hGetClientCommand :: Handle -> IO ClientCommand
 hGetClientCommand = hGetPacketed

--- a/src/Ninja.hs
+++ b/src/Ninja.hs
@@ -1,0 +1,70 @@
+-- |The Ninja module is designed to help you build bots
+-- that play the 'Ninjas' game.  Bots must be a module with
+-- function @ninja :: Ninja@ and a stance @ninjaStance :: Stance@.
+--
+-- There are several levels of ninja, divided into belts of white, blue,
+-- green, red, and black.
+--
+-- The simplest ninja is a 'whiteBelt'. White belts can
+-- control when to attack and where to move while considering
+-- conditional statements reguarding the entire board.  For example:
+--
+-- @
+-- -- FIXME whitebelt example
+-- @
+--
+-- Upon advancement to the blue belt, ninjas obtain better focus.  Blue
+-- belts begin to consider their adversaries individually, deciding to
+-- follow or avoid each enemy in turn.
+--
+-- @
+-- -- FIXME bluebelt example
+-- @
+--
+-- Unfortunately, blue belts tend to forget the patterns of their enemies
+-- but with training they will advance to the green belt.  At that time,
+-- they should learn to remember aspects of their targets behavior and
+-- begin to recognize patterns.
+--
+-- @
+-- -- FIXME greenbelt example
+-- @
+--
+-- Green belts are powerful opponents, but their inability to distinguish
+-- friend from foe makes them dangerous to themselves.  To obtain a red
+-- belt they must be able to distinguish between threats and bystanders.
+--
+-- @
+-- -- FIXME redbelt example
+-- @
+--
+-- To become a ninja there must be no aspect of the battle that is
+-- omitted.  All sights, sounds, and knowledge must be used to defeat
+-- your enemies.
+module Ninja
+    (
+    -- * Types
+    -- ** Basic
+    Ninja, Stance,
+    -- ** Advanced
+    -- *** Triggers
+    BotEvent(..), ServerCommand(..), Command (..), BotHandle,
+    -- *** World data
+    InfoWorld(..),
+    ClientCharacter(..), Character(..), State(..),
+    WalkInfo(..), WaitInfo(..),
+    -- * World Queries
+    boardMax, boardMin,
+    -- * Primitive Commands
+    move, stop, attack, smoke,
+    -- * Administrative
+    start
+    ) where
+
+import Parameters
+import Data.Dynamic
+import NetworkMessages (ServerCommand(..), Command(..))
+import Bot
+
+type Stance = Dynamic
+type Ninja  = BotHandle -> BotEvent -> Dynamic -> IO Dynamic

--- a/src/Ninja/WhiteBelt.hs
+++ b/src/Ninja/WhiteBelt.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DeriveDataTypeable, TupleSections #-}
+-- | White belts are able to use basic logical to
+-- indicate when to attack and where to move.  Due to lack of training,
+-- they don't pay attention to individuals, like if their target is already
+-- dead.  As a result, the whitebelts is most dangerous to himself.
+module Ninja.WhiteBelt
+    ( Ninja, Stance, MoveOp(..), Cond(..)
+    , whiteBelt, horse
+    ) where
+
+import Ninja
+import Bot
+import qualified NetworkMessages as NM
+import qualified Simulation as S
+import Parameters
+
+import Control.Monad (unless)
+import qualified Data.IntMap as IntMap
+import Data.IntMap (IntMap)
+import Data.Dynamic
+import VectorUtils
+import Graphics.Gloss.Data.Vector (magV, dotV, argV, unitVectorAtAngle)
+import Graphics.Gloss.Data.Point
+import Data.List
+import Data.Ord
+import Data.Maybe
+import Data.Data
+
+import System.Random
+
+data MoveOp
+    = Halt         -- ^ Stay still
+    | AvoidEnemy   -- ^ Walk away from the closest person
+    | TowardEnemy  -- ^ Walk toward the closest person
+    | ToCastle     -- ^ Walk toward the closest castle
+    | RandomWalk   -- ^ Walk somewhere random
+    | Strike       -- ^ Swing your sword!
+    | Continue     -- ^ Do nothing different
+    deriving (Eq, Ord, Show, Read, Enum)
+
+evalMove :: BotHandle -> Int -> [Point] -> InfoWorld -> MoveOp -> IO ()
+evalMove bh _ _ _ Halt = stop bh
+evalMove bh self _ w AvoidEnemy  = do
+    let nme  = getClosestEnemy self w
+    case nme of
+        Nothing -> return ()
+        Just e -> do
+            let me   = getSelf self w
+                newDir = unitVectorAtAngle $ (pi/2) + argV (charFacing e)
+                dest = addPt (charPos me) (mulPt (10,10) newDir)
+                mulPt (x1,x2) (y1,y2) = (x1*y1,x2*y2)
+            move bh dest
+evalMove bh self _ w TowardEnemy = do
+    let e = getClosestEnemy self w
+    maybe (return ()) (move bh . charPos) e
+evalMove bh self cs w ToCastle = do
+    let me = getSelf self w
+        t  = minimumBy (comparing (distance (charPos me))) cs
+    unless (null cs) (move bh t)
+evalMove bh _ _ _ RandomWalk  = do
+    x <- randomRIO (fst boardMin, fst boardMax)
+    y <- randomRIO (snd boardMin, snd boardMax)
+    let dst = (x,y)
+    move bh dst
+evalMove bh _ _ _ Strike = attack bh
+evalMove _  _ _ _ Continue = return ()
+
+data Cond = EnemyInReach        -- ^ Closest enemy within striking range
+          | EnemyFacing       -- ^ Closest enemy is facing toward you
+          | EnemyBackTurned     -- ^ Closest enemy is facing away from you
+          | EnemyBehind         -- ^ Closest enemy is behind you
+          | EnemyInFront        -- ^ Closest enemy is infront of you
+          | Stopped             -- ^ You are stopped
+          | CondRandom Float    -- ^ Randomly with a probability (0-1)
+          | AND Cond Cond
+          | OR Cond Cond
+          deriving (Eq, Ord, Show, Read)
+
+consideringClosest :: (Character -> Character -> Bool) -> Int -> InfoWorld -> Bool
+consideringClosest f self w =
+    let enemy = getClosestEnemy self w
+        me    = getSelf self w
+    in maybe False (`f` me) enemy
+
+evalCond :: Int -> InfoWorld -> Cond -> IO Bool
+evalCond self w (AND a b) = do
+    let e = evalCond self w
+    aE <- e a
+    bE <- e b
+    return (aE && bE)
+evalCond self w (OR a b) = do
+    let e = evalCond self w
+    aE <- e a
+    bE <- e b
+    return (aE || bE)
+evalCond self w EnemyInReach =
+    let f n me =
+            let np = charPos n
+                mp = charPos me
+            in magV (subPt np mp) <= attackDistance
+    in return $ consideringClosest f self w
+
+evalCond self w EnemyFacing = return $ consideringClosest facing self w
+evalCond self w EnemyBackTurned = not `fmap` evalCond self w EnemyFacing
+evalCond self w EnemyBehind  = not `fmap` evalCond self w EnemyInFront
+evalCond self w EnemyInFront = return $ consideringClosest (flip facing) self w
+evalCond self w Stopped = do
+    let me = getSelf self w
+    return $ case charState me of
+                Waiting _ -> True
+                _ -> False
+evalCond _ _ (CondRandom p) = do
+    r <- randomRIO (0,1)
+    return $ r <= p
+
+-- @a `facing` b@ is True iff @b@ is in the attack angle of @a@.
+facing :: Character -> Character -> Bool
+facing a b = front || top
+  where
+  top   = charPos a == charPos b
+  front = cos attackAngle * attackLen
+       <= charFacing a `dotV` attackVector
+
+  attackVector = subPt (charPos b) (charPos a)
+  attackLen    = magV attackVector
+
+getSelf :: Int -> InfoWorld -> Character
+getSelf k w = fromMaybe (error "Self not found")
+                        (IntMap.lookup k (infoCharacters w))
+
+getClosestEnemy :: Int -> InfoWorld -> Maybe Character
+getClosestEnemy me w =
+    let self      = getSelf me w
+        dist targ = distance (charPos targ) (charPos self)
+    in minimumMayBy (comparing dist)
+       . IntMap.elems . everyoneElse me $ w
+
+distance :: Point -> Point -> Float
+distance p1 p2 = magV $ subPt p1 p2
+
+minimumMayBy :: (a -> a -> Ordering) -> [a] -> Maybe a
+minimumMayBy _ [] = Nothing
+minimumMayBy f xs = Just (minimumBy f xs)
+
+-- Get everyone who isn't dead or currently stunned
+everyone :: InfoWorld -> IntMap Character
+everyone = IntMap.filter (\c -> (not . (== Dead) . charState $ c)
+                             && (not . isStunned) c)
+         . infoCharacters
+  where
+      isStunned (Character _ _ (Waiting i)) = waitStunned i
+      isStunned _ = False
+
+everyoneElse :: Int -> InfoWorld -> IntMap Character
+everyoneElse me = IntMap.filterWithKey (\k _ -> k /= me) . everyone
+
+whiteBelt :: [(Cond,MoveOp)] -> Ninja
+whiteBelt _ _ (Cmd (NM.SetWorld _,_))  _ = return $ toDyn Init
+whiteBelt _ _ (Cmd (NM.ServerReady,_)) _ = return $ toDyn Init
+whiteBelt conds bh be stance = do
+    newStance <- identifySelf bh be stance
+    case newStance of
+        KnowSelf self cs -> do
+            let selfLoc = charPos (getSelf self w)
+                cs' = filter (not . (selfLoc `S.isInPillar`)) cs
+            case be of
+                Tick _ -> kata self cs'
+                _      -> return ()
+            return $ toDyn $ KnowSelf self cs'
+        _                -> return (toDyn newStance)
+  where
+  w = worldOf be
+
+  kata :: Int -> [Point] -> IO ()
+  kata self remPillars = do
+    cs  <- mapM (evalCond self w . fst) conds
+    let ops = zip cs (map snd conds)
+        rs = [o | (c,o) <- ops, c]
+    maybe (return ()) (evalMove bh self remPillars w) (listToMaybe rs)
+
+-- |By issuing a random initial move we can identify ourselves with very
+-- high probability.
+identifySelf :: BotHandle -> BotEvent -> Dynamic -> IO Horse
+identifySelf bh be dyn =
+    case fromDyn dyn Init of
+        Init -> doMove
+        x@(MoveTo dst ticks) ->
+            case be of
+                Cmd (NM.ServerCommand i (NM.Move _ p),_) | p == dst ->
+                    return $ KnowSelf i pillars
+                Tick _ -> if ticks > maxTicksForSelfId
+                           then doMove
+                           else return (MoveTo dst (ticks + 1))
+                _ -> return x
+        x -> return x
+  where
+  maxTicksForSelfId = 20 -- 1 second assuming the default 20hz
+  doMove = do
+    x <- randomRIO (fst boardMin, fst boardMax)
+    y <- randomRIO (snd boardMin, snd boardMax)
+    let dst = (x,y)
+    move bh dst
+    return $ MoveTo dst 0
+
+-- | With the horse stance a ninja truely knows one's self.
+horse :: Stance
+horse = toDyn (Init :: Horse)
+
+data Horse = MoveTo Point Int | KnowSelf Int [Point] | Init
+    deriving (Data,Typeable)


### PR DESCRIPTION
Two years ago (?) I added these bots to Ninjas with the idea that I
could motivate young programmers by allowing them to earn belts (white,
green, yellow, etc) as they increase their programming skills.  The
project went on hold because my target audience wasn't ready for the
command line... but now they're older!
- From command line invocation there is now a new 'bot' option that
  allows you to provide a Haskell source file (module 'Bot') and define
  a 'ninjaStance'.  Several helpers exist in WhiteBelt and I can provide
  a few of the toy examples if those belong in the repo.
- Upon invocation, the bot's source is interpreted via hint every ~50ms.
  The bot, often referred to as a ninja, can return commands such as
  move, attack, and stop.  These command along with a bot-specific state
  of type Dynamic are returned by the interpreter.  The command is
  passed to the server while the ninja state along with the next world
  state is passed back to the bot after another 50ms.
- A 10 year old seems ready to deal with Ninjas, including command line
  invocation.
- The <8 year olds would probably benefit from a menu that would start
  the game and add bots instead of three commands for server, bot,
  and client.
- Young players might preferr non-letter controls (ctrl~attack alt~smoke or mouse1/2)
- No lesson plan exists, though some toy bots are laying around.
